### PR TITLE
fix(Yoast): add trailing slash to paginated archive canonical URLs

### DIFF
--- a/classes/Compatibility/Yoast.php
+++ b/classes/Compatibility/Yoast.php
@@ -243,7 +243,7 @@ final class Yoast
 
         $isUrlPaged = $pageNumberFromUrl > 0;
         if ($isUrlPaged) {
-            $newLink = trailingslashit($archiveUrl) . trailingslashit($pagedPaginationBase) . $pageNumberFromUrl;
+            $newLink = trailingslashit(trailingslashit($archiveUrl) . $pagedPaginationBase . '/' . $pageNumberFromUrl);
         } else {
             $newLink = trailingslashit($archiveUrl);
         }

--- a/post-type-archive-pages-and-permalink-settings.php
+++ b/post-type-archive-pages-and-permalink-settings.php
@@ -4,7 +4,7 @@
  * Plugin Name:       PTAPS - Post Type Archive Pages and Permalink Settings
  * Plugin URI:        https://github.com/timohubois/post-type-archive-pages-and-permalink-settings/
  * Description:       Use archive pages for custom post types and improve WordPress SEO by managing permalinks for custom post types and taxonomies.
- * Version:           2.2.2
+ * Version:           2.2.3
  * Requires at least: 6.0
  * Requires PHP:      8.0
  * Author:            Timo Hubois

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: timohubois
 Tags: custom post types, custom taxonomy, archives, permalink
 Requires at least: 6.0
 Tested up to: 6.8
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -91,6 +91,9 @@ Regular not but if you have any trouble it's a good practice to resave your perm
 This ensures that WordPress regenerates its rewrite rules with your new settings.
 
 == Changelog ==
+= 2.2.3 =
+* fix canonical URL trailing slash for paginated archive pages in Yoast SEO compatibility
+
 = 2.2.2 =
 * avoid 404 redirect on search results in WPML compatibility
 


### PR DESCRIPTION
## Summary
- Fixes canonical URL generation for paginated archive pages to include trailing slash, preventing 301 redirects and ensuring self-referencing canonical URLs for SEO

## Changes
- Modified `classes/Compatibility/Yoast.php` line 246 to use nested `trailingslashit()` calls for safer URL construction
- Bumped version to 2.2.3
- Updated changelog in readme.txt

## Technical Details
**Issue:** Paginated archive pages (e.g., `/retailers/page/4/`) generated canonical URLs without trailing slashes (`/retailers/page/4`), causing 301 redirects since WordPress permalink structure uses trailing slashes.

**Fix:** Changed from manual slash concatenation to nested `trailingslashit()` calls to safely ensure trailing slash while preventing double slashes:
```php
$newLink = trailingslashit(trailingslashit($archiveUrl) . $pagedPaginationBase . '/' . $pageNumberFromUrl);
```

## Impact
Improves SEO by ensuring canonical URLs are self-referencing and eliminates unnecessary 301 redirects on paginated archive pages.